### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -49,12 +49,12 @@
               Je publie du code principalement sur <a href="https://github.com/benoitbryon/">Github</a>
               (des archives sur <a href="https://bitbucket.org/benoitbryon/">Bitbucket</a>).
               J'ai créé et je maintiens plusieurs bibliothèques pour Django, comme
-              <a href="https://django-downloadview.readthedocs.org">django-downloadview</a> ou
-              <a href="https://django-ticketoffice.readthedocs.org">django-ticketoffice</a>.
+              <a href="https://django-downloadview.readthedocs.io">django-downloadview</a> ou
+              <a href="https://django-ticketoffice.readthedocs.io">django-ticketoffice</a>.
               Je suis également fier
-              du tandem <a href="https://diecutter.readthedocs.org">diecutter</a>/<a href="https://piecutter.readthedocs.org">piecutter</a>,
-              de <a href="https://xal.readthedocs.org">xal</a> ou bien encore
-              de <a href="https://transmutator.readthedocs.org">transmutator</a>.
+              du tandem <a href="https://diecutter.readthedocs.io">diecutter</a>/<a href="https://piecutter.readthedocs.io">piecutter</a>,
+              de <a href="https://xal.readthedocs.io">xal</a> ou bien encore
+              de <a href="https://transmutator.readthedocs.io">transmutator</a>.
             </p>
             <p>Mes rares <a href="https://twitter.com/benoitbryon">tweets</a> parlent de développement web.</p>
             <p>J'ai rédigé quelques articles techniques sur <a href="http://tech.novapost.fr/author/benoit-bryon.html">tech.novapost.fr</a> et sur <a href="http://makina-corpus.com/@@search?SearchableText=benoit+bryon">makina-corpus.com</a>.</p>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.